### PR TITLE
Add interactive pie chart with customer details

### DIFF
--- a/admin/Dashboard.html
+++ b/admin/Dashboard.html
@@ -45,8 +45,9 @@
     .chart-wrapper {
       flex: 1;
       display: flex;
+      flex-direction: column;
       align-items: center;
-      justify-content: center;
+      justify-content: flex-start;
       padding: 20px;
     }
     .chart-box {
@@ -56,6 +57,24 @@
       padding: 20px;
       border-radius: 8px;
       box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    }
+    .table-container {
+      width: 100%;
+      max-width: 600px;
+      background: #fff;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+      margin-top: 20px;
+    }
+    #customerTable {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    #customerTable th, #customerTable td {
+      padding: 8px;
+      border-bottom: 1px solid #ddd;
+      text-align: left;
     }
   </style>
 </head>
@@ -74,6 +93,18 @@
   <div class="chart-wrapper">
     <div class="chart-box">
       <canvas id="sentimentChart"></canvas>
+    </div>
+    <div class="table-container" id="tableContainer" style="display:none;">
+      <table id="customerTable">
+        <thead>
+          <tr>
+            <th>Customer</th>
+            <th>Date</th>
+            <th>Summary</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
   </div>
 <script>
@@ -94,6 +125,7 @@
     sentiment: sentiments[Math.floor(Math.random()*sentiments.length)],
     summary: `Feedback ${i+1}`
   }));
+  let filteredRecords = records.slice();
 
   const ctx = document.getElementById('sentimentChart').getContext('2d');
   const chart = new Chart(ctx, {
@@ -116,12 +148,34 @@
     const now = new Date();
     const past = new Date();
     past.setDate(now.getDate() - range);
-    const filtered = records.filter(r => r.date >= past);
+    filteredRecords = records.filter(r => r.date >= past);
     const counts = {Positive:0, Neutral:0, Challenging:0};
-    filtered.forEach(r=>{ counts[r.sentiment]++; });
+    filteredRecords.forEach(r=>{ counts[r.sentiment]++; });
     chart.data.datasets[0].data = sentiments.map(s=>counts[s]);
     chart.update();
+    document.getElementById('tableContainer').style.display = 'none';
   }
+
+  function showCustomers(sentiment){
+    const tbody = document.querySelector('#customerTable tbody');
+    tbody.innerHTML = '';
+    const subset = filteredRecords.filter(r => r.sentiment === sentiment);
+    subset.forEach(r=>{
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${r.customerName}</td><td>${r.date.toLocaleDateString()}</td><td>${r.summary}</td>`;
+      tbody.appendChild(tr);
+    });
+    document.getElementById('tableContainer').style.display = subset.length ? 'block' : 'none';
+  }
+
+  document.getElementById('sentimentChart').addEventListener('click', function(evt){
+    const points = chart.getElementsAtEventForMode(evt, 'nearest', {intersect:true}, true);
+    if(points.length){
+      const idx = points[0].index;
+      const sentiment = chart.data.labels[idx];
+      showCustomers(sentiment);
+    }
+  });
 
   document.getElementById('durationSelect').addEventListener('change', updateChart);
   updateChart();


### PR DESCRIPTION
## Summary
- show the pie chart and customers in a column layout
- add a hidden table to display customers
- update script to filter by range and handle pie clicks

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6842c3a37a2c8333aac385dc72c743fc